### PR TITLE
According to newer ethers versions the README.md requires this update

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ export const EASContractAddress = "0xC2679fBD37d54388Ce493F1DB75320D236e1815e"; 
 const eas = new EAS(EASContractAddress);
 
 // Gets a default provider (in production use something else like infura/alchemy)
-const provider = ethers.providers.getDefaultProvider(
+const provider = ethers.getDefaultProvider(
   "sepolia"
 );
 


### PR DESCRIPTION
ethers.getDefaultProvider("sepolia")

instead of 

ethers.providers.getDefaultProvider("sepolia")