### PR TITLE
Migrate Artifact Actions to v4 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install PNPM
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Artifact Actions v3 will be deprecated on January 30, 2025. To prevent workflow failures, this PR updates the action versions in line with the official migration guide provided by GitHub.

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
