### PR TITLE
Fix nested tuple schema decoding

### DIFF
--- a/src/schema-encoder.ts
+++ b/src/schema-encoder.ts
@@ -59,8 +59,8 @@ export class SchemaEncoder {
 
       const isArray = arrayChildren;
       const components = paramType.components ?? arrayChildren?.components ?? [];
-      const componentsType = `(${components.map((c) => c.type).join(',')})${isArray ? '[]' : ''}`;
-      const componentsFullType = `(${components.map((c) => (c.name ? `${c.type} ${c.name}` : c.type)).join(',')})${
+      const componentsType = `(${components.map((c) => SchemaEncoder.formatComponent(c)).join(',')})${isArray ? '[]' : ''}`;
+      const componentsFullType = `(${components.map((c) => SchemaEncoder.formatComponent(c, true)).join(',')})${
         isArray ? '[]' : ''
       }`;
 
@@ -135,43 +135,26 @@ export class SchemaEncoder {
       const components = input.components ?? input.arrayChildren?.components ?? [];
 
       if (value.length > 0 && typeof value !== STRING && components?.length > 0) {
-        if (Array.isArray(value[0])) {
-          const namedValues = [];
+        const toNamedValue = (tupleValue: unknown[], tupleComponents: typeof components): SchemaItem[] =>
+          tupleValue.map((v, k) => {
+            const component = tupleComponents[k];
+            const nestedComponents = component.components ?? component.arrayChildren?.components ?? [];
 
-          for (const val of value) {
-            const namedValue = [];
-            const rawValues = val.toArray().filter((v: unknown) => typeof v !== 'object');
+            return {
+              name: component.name,
+              type: component.type,
+              value: Array.isArray(v) && nestedComponents.length > 0 ? toNamedValue(v, nestedComponents) : (v as SchemaValue)
+            };
+          });
 
-            for (const [k, v] of rawValues.entries()) {
-              const component = components[k];
-
-              namedValue.push({ name: component.name, type: component.type, value: v });
-            }
-
-            namedValues.push(namedValue);
-          }
-
-          value = {
-            name: s.name,
-            type: s.type,
-            value: namedValues
-          };
-        } else {
-          const namedValue = [];
-          const rawValues = value.filter((v: unknown) => typeof v !== 'object');
-
-          for (const [k, v] of rawValues.entries()) {
-            const component = components[k];
-
-            namedValue.push({ name: component.name, type: component.type, value: v });
-          }
-
-          value = {
-            name: s.name,
-            type: s.type,
-            value: namedValue
-          };
-        }
+        value = {
+          name: s.name,
+          type: s.type,
+          value:
+            input.baseType === 'array'
+              ? value.map((val: unknown[]) => toNamedValue(val, components))
+              : toNamedValue(value, components)
+        };
       } else {
         value = { name: s.name, type: s.type, value };
       }
@@ -234,6 +217,15 @@ export class SchemaEncoder {
 
   private static getDefaultValueForTypeName(typeName: string) {
     return typeName === BOOL ? false : typeName.includes(UINT) ? '0' : typeName === ADDRESS ? ZERO_ADDRESS : '';
+  }
+
+  private static formatComponent(component: FunctionFragment['inputs'][number], includeName = false): string {
+    const components = component.components ?? component.arrayChildren?.components ?? [];
+    const type = components.length > 0 ? `(${components.map((c) => SchemaEncoder.formatComponent(c, includeName)).join(',')})` : component.type;
+    const arraySuffix = component.baseType === 'array' ? '[]' : '';
+    const nameSuffix = includeName && component.name ? ` ${component.name}` : '';
+
+    return `${type}${arraySuffix}${nameSuffix}`;
   }
 
   private static decodeIpfsValue(val: string) {

--- a/test/test/schema-encoder.ts
+++ b/test/test/schema-encoder.ts
@@ -117,6 +117,17 @@ describe('SchemaEncoder', () => {
         ]
       },
       {
+        schema: '((string key,uint8 value) inner,uint256 id) outer',
+        decodedSchema: [
+          {
+            name: 'outer',
+            type: '((string,uint8),uint256)',
+            signature: '((string key,uint8 value) inner,uint256 id) outer',
+            value: ''
+          }
+        ]
+      },
+      {
         schema:
           // eslint-disable-next-line max-len
           'string contractGroupName,string ipfsHash,string readmeIpfsHash,address[] contractAddresses,string[] contractNames,string[] contractNetworks,string[] contractIpfsHashes',
@@ -548,6 +559,38 @@ describe('SchemaEncoder', () => {
                     { name: 'badgeId', type: 'uint256', value: 3n },
                     { name: 'level', type: 'uint256', value: 30n }
                   ]
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        schema: '((string key,uint8 value) inner,uint256 id) outer',
+        types: ['((string key,uint8 value) inner,uint256 id)'],
+        inputs: [
+          {
+            in: [
+              {
+                type: '((string,uint8),uint256)',
+                name: 'outer',
+                value: { inner: { key: 'entry1', value: 7n }, id: 42n }
+              }
+            ],
+            out: [
+              {
+                type: '((string,uint8),uint256)',
+                name: 'outer',
+                value: [
+                  {
+                    name: 'inner',
+                    type: 'tuple(string,uint8)',
+                    value: [
+                      { name: 'key', type: 'string', value: 'entry1' },
+                      { name: 'value', type: 'uint8', value: 7n }
+                    ]
+                  },
+                  { name: 'id', type: 'uint256', value: 42n }
                 ]
               }
             ]


### PR DESCRIPTION
Fixes nested tuple schema handling in the schema encoder.

The patch keeps nested tuple components in the generated type/signature path and preserves nested tuple values during decode instead of filtering object-like entries out.

Covered with tests for:
- nested tuple schema construction
- encode/decode round trips with nested tuple values

Checked with:
- `pnpm lint`
- `pnpm build`
- `cd test && pnpm hardhat test test/schema-encoder.ts`